### PR TITLE
Workout activity types

### DIFF
--- a/HealthKitReporter/Classes/Decorator/Extensions+HKWorkoutActivityType.swift
+++ b/HealthKitReporter/Classes/Decorator/Extensions+HKWorkoutActivityType.swift
@@ -1,0 +1,105 @@
+//
+//  Extensions+HKQuantityType.swift
+//  HealthKitReporter
+//
+//  Created by Oliver Searle-Barnes on 01.04.21.
+//
+
+import Foundation
+import HealthKit
+
+extension HKWorkoutActivityType {
+
+    /*
+     Simple mapping of available workout types to a human readable name.
+     */
+    var name: String {
+        switch self {
+        case .americanFootball:             return "American Football"
+        case .archery:                      return "Archery"
+        case .australianFootball:           return "Australian Football"
+        case .badminton:                    return "Badminton"
+        case .baseball:                     return "Baseball"
+        case .basketball:                   return "Basketball"
+        case .bowling:                      return "Bowling"
+        case .boxing:                       return "Boxing"
+        case .climbing:                     return "Climbing"
+        case .crossTraining:                return "Cross Training"
+        case .curling:                      return "Curling"
+        case .cycling:                      return "Cycling"
+        case .dance:                        return "Dance"
+        case .danceInspiredTraining:        return "Dance Inspired Training"
+        case .elliptical:                   return "Elliptical"
+        case .equestrianSports:             return "Equestrian Sports"
+        case .fencing:                      return "Fencing"
+        case .fishing:                      return "Fishing"
+        case .functionalStrengthTraining:   return "Functional Strength Training"
+        case .golf:                         return "Golf"
+        case .gymnastics:                   return "Gymnastics"
+        case .handball:                     return "Handball"
+        case .hiking:                       return "Hiking"
+        case .hockey:                       return "Hockey"
+        case .hunting:                      return "Hunting"
+        case .lacrosse:                     return "Lacrosse"
+        case .martialArts:                  return "Martial Arts"
+        case .mindAndBody:                  return "Mind and Body"
+        case .mixedMetabolicCardioTraining: return "Mixed Metabolic Cardio Training"
+        case .paddleSports:                 return "Paddle Sports"
+        case .play:                         return "Play"
+        case .preparationAndRecovery:       return "Preparation and Recovery"
+        case .racquetball:                  return "Racquetball"
+        case .rowing:                       return "Rowing"
+        case .rugby:                        return "Rugby"
+        case .running:                      return "Running"
+        case .sailing:                      return "Sailing"
+        case .skatingSports:                return "Skating Sports"
+        case .snowSports:                   return "Snow Sports"
+        case .soccer:                       return "Soccer"
+        case .softball:                     return "Softball"
+        case .squash:                       return "Squash"
+        case .stairClimbing:                return "Stair Climbing"
+        case .surfingSports:                return "Surfing Sports"
+        case .swimming:                     return "Swimming"
+        case .tableTennis:                  return "Table Tennis"
+        case .tennis:                       return "Tennis"
+        case .trackAndField:                return "Track and Field"
+        case .traditionalStrengthTraining:  return "Traditional Strength Training"
+        case .volleyball:                   return "Volleyball"
+        case .walking:                      return "Walking"
+        case .waterFitness:                 return "Water Fitness"
+        case .waterPolo:                    return "Water Polo"
+        case .waterSports:                  return "Water Sports"
+        case .wrestling:                    return "Wrestling"
+        case .yoga:                         return "Yoga"
+
+        // iOS 10
+        case .barre:                        return "Barre"
+        case .coreTraining:                 return "Core Training"
+        case .crossCountrySkiing:           return "Cross Country Skiing"
+        case .downhillSkiing:               return "Downhill Skiing"
+        case .flexibility:                  return "Flexibility"
+        case .highIntensityIntervalTraining:    return "High Intensity Interval Training"
+        case .jumpRope:                     return "Jump Rope"
+        case .kickboxing:                   return "Kickboxing"
+        case .pilates:                      return "Pilates"
+        case .snowboarding:                 return "Snowboarding"
+        case .stairs:                       return "Stairs"
+        case .stepTraining:                 return "Step Training"
+        case .wheelchairWalkPace:           return "Wheelchair Walk Pace"
+        case .wheelchairRunPace:            return "Wheelchair Run Pace"
+
+        // iOS 11
+        case .taiChi:                       return "Tai Chi"
+        case .mixedCardio:                  return "Mixed Cardio"
+        case .handCycling:                  return "Hand Cycling"
+
+        // iOS 13
+        case .discSports:                   return "Disc Sports"
+        case .fitnessGaming:                return "Fitness Gaming"
+
+        // Catch-all
+        default:                            return "Other"
+        }
+    }
+
+}

--- a/HealthKitReporter/Classes/Model/Payload/Workout.swift
+++ b/HealthKitReporter/Classes/Model/Payload/Workout.swift
@@ -109,7 +109,7 @@ public struct Workout: Identifiable, Sample {
         self.endTimestamp = workout.endDate.timeIntervalSince1970
         self.device = Device(device: workout.device)
         self.sourceRevision = SourceRevision(sourceRevision: workout.sourceRevision)
-        self.workoutName = String(describing: workout.workoutActivityType)
+        self.workoutName = String(describing: workout.workoutActivityType.name)
         self.duration = workout.duration
         guard #available(iOS 11.0, *) else {
             throw HealthKitError.notAvailable(


### PR DESCRIPTION
## Status
IN DEVELOPMENT

Currently there's no way to get the Workout activity name from the Workout struct. There is

```
self.workoutName = String(describing: workout.workoutActivityType)
```
at https://github.com/VictorKachalov/HealthKitReporter/blob/master/HealthKitReporter/Classes/Model/Payload/Workout.swift#L112 but it just returns the string `"HKWorkoutActivityType"`.

This PR will add the activity type (using as a reference https://stackoverflow.com/questions/30175237/how-to-get-the-name-of-hkworkoutactivitytype-in-healthkit). 

Open questions:
1) Should we add the field `workout.activityType` alongside the current `workoutName` (aligning with the enum type)
2) Naming of the string values - currently the format is presentation based, but as it's effectively a serialised value perhaps another format would make sense? (personally I'm happy with it as is but happy to go with whatever).

## Migrations
NO

## Description
Adding a string representation of the activity type to workout payload

## Related PRs
pending: PR for health_kit_reporter



