### PR TITLE
Make `averageHeartRate` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.0] - 23.06.2022.
+
+* Make `averageHeartRate` optional as a `HKElectrocardiogram.Classification.inconclusivePoorReading` may not have a value for this field
+
 ## [1.6.9] - 27.05.2022.
 
 * Add copyWith methods to Correlation

--- a/HealthKitReporter.podspec
+++ b/HealthKitReporter.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name                  = 'HealthKitReporter'
-  s.version               = '1.6.9'
+  s.version               = '1.7.0'
   s.summary               = 'HealthKitReporter. A wrapper for HealthKit framework.'
   s.swift_versions        = '5.3'
   s.description           = 'Helps to write or read data from Apple Health via HealthKit framework.'

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Decorator/Extensions+HKElectrocardiogram.swift
+++ b/Sources/Decorator/Extensions+HKElectrocardiogram.swift
@@ -13,13 +13,8 @@ extension HKElectrocardiogram {
 
     func harmonize(voltageMeasurements: [Electrocardiogram.VoltageMeasurement]) throws -> Harmonized {
         let averageHeartRateUnit = HKUnit.count().unitDivided(by: HKUnit.minute())
-        guard
-            let averageHeartRate = averageHeartRate?.doubleValue(for: averageHeartRateUnit)
-        else {
-            throw HealthKitError.invalidValue(
-                "Invalid averageHeartRate value for HKElectrocardiogram"
-            )
-        }
+        let averageHeartRate = averageHeartRate?.doubleValue(for: averageHeartRateUnit)
+        
         let samplingFrequencyUnit = HKUnit.hertz()
         guard
             let samplingFrequency = samplingFrequency?.doubleValue(for: samplingFrequencyUnit)

--- a/Sources/Model/Payload/Electrocardiogram.swift
+++ b/Sources/Model/Payload/Electrocardiogram.swift
@@ -10,7 +10,7 @@ import HealthKit
 @available(iOS 14.0, *)
 public struct Electrocardiogram: Identifiable, Sample {
     public struct Harmonized: Codable {
-        public let averageHeartRate: Double
+        public let averageHeartRate: Double?
         public let averageHeartRateUnit: String
         public let samplingFrequency: Double
         public let samplingFrequencyUnit: String
@@ -21,7 +21,7 @@ public struct Electrocardiogram: Identifiable, Sample {
         public let metadata: [String: String]?
 
         init(
-            averageHeartRate: Double,
+            averageHeartRate: Double?,
             averageHeartRateUnit: String,
             samplingFrequency: Double,
             samplingFrequencyUnit: String,


### PR DESCRIPTION
## Status
READY

## Migrations
NO

## Description
There is no option to collect the voltage measurements for electrograms with inconclusive poor readings because they do not have any value for `averageHeartRate`. Therefore, we should allow for `nil` value for `averageHeartRate`.