### PR TITLE
Add discreteMax quantity to statistics

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,8 +12,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Generate project
-      run: swift package generate-xcodeproj
     - name: Build
       run: xcodebuild clean build -project "HealthKitReporter.xcodeproj" -scheme "HealthKitReporter-Package" -destination "platform=iOS Simulator,name=iPhone 12 Pro,OS=latest" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
     - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.2.0] - 13.11.2024.
+
+* Add discreteMax quantity to statistics' options
+
 ## [3.1.0] - 08.01.2024.
 
 * Added support for HKClinicalRecord

--- a/HealthKitReporter.podspec
+++ b/HealthKitReporter.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name                  = 'HealthKitReporter'
-  s.version               = '3.1.0'
+  s.version               = '3.2.0'
   s.summary               = 'HealthKitReporter. A wrapper for HealthKit framework.'
   s.swift_versions        = '5.3'
   s.description           = 'Helps to write or read data from Apple Health via HealthKit framework.'

--- a/Sources/Decorator/Extensions+HKQuantityType.swift
+++ b/Sources/Decorator/Extensions+HKQuantityType.swift
@@ -24,7 +24,7 @@ extension HKQuantityType {
         case .discreteArithmetic,
              .discreteTemporallyWeighted,
              .discreteEquivalentContinuousLevel:
-            return .discreteAverage
+            return [.discreteAverage, .discreteMax]
         @unknown default:
             fatalError()
         }


### PR DESCRIPTION
Issue: https://github.com/kvs-coder/HealthKitReporter/issues/27

## Status
READY

## Migrations
NO

## Description
Getting `discreteMax` alongside `discreteAverage` in Statistics.

## Related PRs
Not applicable.
 
## Deploy Notes
Not applicable.

## Steps to Test or Reproduce
```
git pull --prune
git checkout add-max-to-statistics
```

## Impacted Areas in Application
Getting `Statistics`' `max` value will not return null.

## List general components of the application that this PR will affect:
`HKQuantityType`'s extension
`Statistics`
